### PR TITLE
Display timestamps in Craft's timezone

### DIFF
--- a/src/models/ActivityLog.php
+++ b/src/models/ActivityLog.php
@@ -12,6 +12,7 @@
 namespace nav33d\activitylog\models;
 
 use Craft;
+use craft\helpers\DateTimeHelper;
 use DateTime;
 use craft\base\Model;
 use craft\elements\Asset;
@@ -197,7 +198,9 @@ class ActivityLog extends Model
         $model->userAgent               = $record->userAgent;
         $model->siteId                  = $record->siteId;
         $model->userId                  = $record->userId;
-        $model->dateCreated             = $record->dateCreated;
+        $model->dateCreated             =
+            DateTimeHelper::toDateTime($record->dateCreated, false, true)
+                ->format('Y-m-d H:i:s');
 
         return $model;
     }

--- a/src/services/ActivityLog.php
+++ b/src/services/ActivityLog.php
@@ -13,6 +13,7 @@ namespace nav33d\activitylog\services;
 
 use Craft;
 use craft\db\Query;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\UrlHelper;
 
@@ -67,6 +68,7 @@ class ActivityLog extends Component
         foreach( $logs as &$log )
         {
             $log['viewLink'] = UrlHelper::cpUrl('activitylog/'.$log['id']);
+            $log['dateCreated'] = DateTimeHelper::toDateTime($log['dateCreated'], false, true)->format('Y-m-d H:i:s');
         }
         
         $data['data'] = $logs;


### PR DESCRIPTION
Timestamps appear to be stored in UTC. I am very new to Craft and this appears to be standard behaviour.

The dateCreated timestamps extracted from the database remain in UTC for display.

These changes will translate the timestamp into Craft's selected timezone for display, and much more relevant to the user.